### PR TITLE
Fix error where if "graze" or "piper" was inputted graze would crash.

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 		}
 
 		if rl.IsKeyDown(rl.KeyEnter) && !grazeCores[currTab].QueryActive {
-			if len(strings.Split(grazeCores[currTab].QBCurrentURL, "/")) >= 2{
+			if len(strings.Split(grazeCores[currTab].QBCurrentURL, "://")) >= 2{
 				scrollOffset = 0
 				grazeCores[currTab].TargetRenderFrames += 4
 				grazeCores[currTab].SBStatus = "load"

--- a/main.go
+++ b/main.go
@@ -112,11 +112,13 @@ func main() {
 		}
 
 		if rl.IsKeyDown(rl.KeyEnter) && !grazeCores[currTab].QueryActive {
-			scrollOffset = 0
-			grazeCores[currTab].TargetRenderFrames += 4
-			grazeCores[currTab].SBStatus = "load"
-			tabs[currTab] = strings.Split(grazeCores[currTab].QBCurrentURL, "/")[len(strings.Split(grazeCores[currTab].QBCurrentURL, "/"))-1]
-			go grazeCores[currTab].Query()
+			if len(strings.Split(grazeCores[currTab].QBCurrentURL, "/")) >= 2{
+				scrollOffset = 0
+				grazeCores[currTab].TargetRenderFrames += 4
+				grazeCores[currTab].SBStatus = "load"
+				tabs[currTab] = strings.Split(grazeCores[currTab].QBCurrentURL, "/")[len(strings.Split(grazeCores[currTab].QBCurrentURL, "/"))-1]
+				go grazeCores[currTab].Query()
+			}
 		}
 
 		/* Main GUI */


### PR DESCRIPTION
If "graze" or "piper" was inputted without a URL after it, graze will crash.